### PR TITLE
feat: teams data processing

### DIFF
--- a/src/api/__snapshots__/players.test.ts.snap
+++ b/src/api/__snapshots__/players.test.ts.snap
@@ -1,5 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`api/players get returns parsed players map from local players.csv file 1`] = `
+Object {
+  "alerom": Object {
+    "alias": "Саша Романихин",
+    "firstname": "Саша",
+    "lastname": "Романихин",
+    "name": "alerom",
+    "photoURL": null,
+  },
+  "andbor": Object {
+    "alias": "Андрей Борода",
+    "firstname": "Андрей",
+    "lastname": "Борода",
+    "name": "andbor",
+    "photoURL": null,
+  },
+  "andrey": Object {
+    "alias": "Андрей",
+    "firstname": "Андрей",
+    "lastname": null,
+    "name": "andrey",
+    "photoURL": null,
+  },
+  "antsav": Object {
+    "alias": "Антон",
+    "firstname": "Антон",
+    "lastname": "Савельев",
+    "name": "antsav",
+    "photoURL": null,
+  },
+  "dangol": Object {
+    "alias": "Данил",
+    "firstname": "Данил",
+    "lastname": "Головачев",
+    "name": "dangol",
+    "photoURL": null,
+  },
+  "dimsha": Object {
+    "alias": "Дима Шальнев",
+    "firstname": "Дима",
+    "lastname": "Шальнев",
+    "name": "dimsha",
+    "photoURL": null,
+  },
+  "ivan": Object {
+    "alias": "Иван",
+    "firstname": "Иван",
+    "lastname": null,
+    "name": "ivan",
+    "photoURL": null,
+  },
+  "kolya": Object {
+    "alias": "Коля",
+    "firstname": "Коля",
+    "lastname": null,
+    "name": "kolya",
+    "photoURL": null,
+  },
+  "kosura": Object {
+    "alias": "Костя",
+    "firstname": "Костя",
+    "lastname": "Ураков",
+    "name": "kosura",
+    "photoURL": null,
+  },
+  "lesha": Object {
+    "alias": "Леша",
+    "firstname": "Леша",
+    "lastname": null,
+    "name": "lesha",
+    "photoURL": null,
+  },
+  "maxche": Object {
+    "alias": "Максим",
+    "firstname": "Максим",
+    "lastname": "Чернов",
+    "name": "maxche",
+    "photoURL": null,
+  },
+  "mismar": Object {
+    "alias": "Миша",
+    "firstname": "Миша",
+    "lastname": "Меренков",
+    "name": "mismar",
+    "photoURL": null,
+  },
+  "vitaku": Object {
+    "alias": "Виталик Акульшин",
+    "firstname": "Виталик",
+    "lastname": "Акульшин",
+    "name": "vitaku",
+    "photoURL": null,
+  },
+  "vitvol": Object {
+    "alias": "Виталик Волнушкин",
+    "firstname": "Виталик",
+    "lastname": "Волнушкин",
+    "name": "vitvol",
+    "photoURL": null,
+  },
+  "vitya": Object {
+    "alias": "Витя",
+    "firstname": "Витя",
+    "lastname": null,
+    "name": "vitya",
+    "photoURL": null,
+  },
+  "zhechi": Object {
+    "alias": "Женя",
+    "firstname": "Женя",
+    "lastname": "Чистов",
+    "name": "zhechi",
+    "photoURL": null,
+  },
+}
+`;
+
 exports[`routes/players get returns parsed players map from local players.csv file 1`] = `
 Object {
   "alerom": Object {

--- a/src/api/__snapshots__/teams.test.ts.snap
+++ b/src/api/__snapshots__/teams.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`api/teams get returns parsed teams map from local teams.csv file 1`] = `
+Object {
+  "blue": Object {
+    "fullname": "Синие",
+    "name": "blue",
+  },
+  "manki": Object {
+    "fullname": "Манишки",
+    "name": "manki",
+  },
+}
+`;

--- a/src/api/players.test.ts
+++ b/src/api/players.test.ts
@@ -1,6 +1,6 @@
-import { get } from 'routes/players'
+import { get } from './players'
 
-describe('routes/players', () => {
+describe('api/players', () => {
   describe('get', () => {
     test('returns parsed players map from local players.csv file', async () => {
       expect(JSON.parse((await get()).body as string)).toMatchSnapshot()

--- a/src/api/teams.test.ts
+++ b/src/api/teams.test.ts
@@ -1,0 +1,9 @@
+import { get } from './teams'
+
+describe('api/teams', () => {
+  describe('get', () => {
+    test('returns parsed teams map from local teams.csv file', async () => {
+      expect(JSON.parse((await get()).body as string)).toMatchSnapshot()
+    })
+  })
+})

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,0 +1,6 @@
+import type { EndpointOutput } from '@sveltejs/kit'
+import { getTeams } from 'lib/teams'
+
+export const get: () => Promise<EndpointOutput> = () => {
+  return new Promise((resolve) => void resolve({ body: JSON.stringify(getTeams()) }))
+}

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,3 @@
+import path from 'path'
+
+export const DATA_DIR = path.join(process.cwd(), 'src', 'data')

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -5,3 +5,8 @@ export interface IPlayer {
   alias?: string
   photoURL?: string
 }
+
+export interface ITeam {
+  name: string
+  fullname: string
+}

--- a/src/data/teams.csv
+++ b/src/data/teams.csv
@@ -1,0 +1,3 @@
+name,fullname
+blue,Синие
+manki,Манишки

--- a/src/lib/__snapshots__/teams.test.ts.snap
+++ b/src/lib/__snapshots__/teams.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`lib/teams getPlayers returns parsed teams map from local teams.csv file 1`] = `
+Object {
+  "blue": Object {
+    "fullname": "Синие",
+    "name": "blue",
+  },
+  "manki": Object {
+    "fullname": "Манишки",
+    "name": "manki",
+  },
+}
+`;

--- a/src/lib/players.ts
+++ b/src/lib/players.ts
@@ -2,8 +2,8 @@ import type { IPlayer } from 'common/interfaces'
 import fs from 'fs'
 import path from 'path'
 import Papa from 'papaparse'
+import { DATA_DIR } from 'common/constants'
 
-const DATA_DIR = path.join(process.cwd(), 'src', 'data')
 const PAPA_CONF: Papa.ParseConfig<IPlayer> = {
   header: true,
   dynamicTyping: true,

--- a/src/lib/teams.test.ts
+++ b/src/lib/teams.test.ts
@@ -1,0 +1,24 @@
+import { mocked } from 'ts-jest/utils'
+import Papa from 'papaparse'
+import { getTeams } from './teams'
+
+describe('lib/teams', () => {
+  describe('getPlayers', () => {
+    test('returns parsed teams map from local teams.csv file', () => {
+      expect(getTeams()).toMatchSnapshot()
+    })
+
+    test('returns empty teams map and prints error to console if something went wrong', () => {
+      jest.spyOn(Papa, 'parse').mockImplementationOnce(() => {
+        throw new Error('Something went wrong')
+      })
+      jest.spyOn(console, 'error')
+
+      expect(getTeams()).toEqual({})
+      expect(mocked(console.error)).toBeCalledWith(expect.any(Error))
+
+      mocked(Papa.parse).mockRestore()
+      mocked(console.error).mockRestore()
+    })
+  })
+})

--- a/src/lib/teams.ts
+++ b/src/lib/teams.ts
@@ -1,0 +1,30 @@
+import type { ITeam } from 'common/interfaces'
+import fs from 'fs'
+import path from 'path'
+import Papa from 'papaparse'
+import { DATA_DIR } from 'common/constants'
+
+const PAPA_CONF: Papa.ParseConfig<ITeam> = {
+  header: true,
+  dynamicTyping: true,
+  skipEmptyLines: true
+}
+
+type PlayerName = ITeam['name']
+
+export const getTeams: () => Record<PlayerName, ITeam> = () => {
+  try {
+    return Papa.parse(fs.readFileSync(path.join(DATA_DIR, 'teams.csv'), 'utf8'), PAPA_CONF).data.reduce(
+      (teams, team) => {
+        teams[team.name] = team
+
+        return teams
+      },
+      {} as Record<PlayerName, ITeam>
+    )
+  } catch (err) {
+    console.error(err)
+
+    return {}
+  }
+}

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -3,20 +3,27 @@
 
   export const load: Load = async ({ fetch }) => {
     try {
-      return { props: { players: await (await fetch('/players')).json() } }
+      return {
+        props: {
+          players: await (await fetch('/players')).json(),
+          teams: await (await fetch('/teams')).json()
+        }
+      }
     } catch (err) {
-      return { props: { players: {} } }
+      return { props: { players: {}, teams: {} } }
     }
   }
 </script>
 
 <script lang="ts">
-  import type { IPlayer } from 'common/interfaces'
+  import type { IPlayer, ITeam } from 'common/interfaces'
   import { setContext } from 'svelte'
 
   export let players: Record<IPlayer['name'], IPlayer>
+  export let teams: Record<ITeam['name'], ITeam>
 
   setContext('players', players)
+  setContext('teams', teams)
 </script>
 
 <slot />


### PR DESCRIPTION
Setup of pipeline for processing base teams data:

* Add teams data as local `data/teams.csv`
* Read and parse `.csv` file to JS map through `Paparase` in `lib/teams.ts`
* Add `api/teams` endpoint for resolving parsed teams data as network request
* Fetch resolved teams data and save it to Svelte context for later usage in root layout component 